### PR TITLE
Fix directory paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ There is only support for normal text messages and voice recordings atm, but i w
 In this repository you will also find a Dockerfile to build a compatible Container, the program requires a config.yaml to work correctly inside a conf folder, the downloaded voice files will be stored inside a web folder inside the conf directory.
 
 ```
-  /opt/telegram2mqtt
-  /opt/telegram2mqtt/telegram2mqtt.py
-  /opt/telegram2mqtt/conf
-  /opt/telegram2mqtt/conf/config.yaml
-  /opt/telegram2mqtt/conf/web
+  /opt/tel2mqtt
+  /opt/tel2mqtt/telegram2mqtt.py
+  /opt/tel2mqtt/conf
+  /opt/tel2mqtt/conf/config.yaml
+  /opt/tel2mqtt/conf/web
 ```
 
 If you are using docker map the config directory to a place outside of the container.


### PR DESCRIPTION
Hello, I found this repo from your [post](https://community.home-assistant.io/t/playback-telegram-voice-messages-using-ha/60027) on the Home Assistant discourse and thank you so much for making this!  I found that the python script references `/opt/tel2mqtt` as the directory path used for the config and other files, while the readme gives `/opt/telegram2mqtt` instead.  This PR simply makes the readme's paths consistent with the python script.